### PR TITLE
getMode Fix

### DIFF
--- a/firmware/uber-library-example.cpp
+++ b/firmware/uber-library-example.cpp
@@ -35,7 +35,7 @@ bool UberLibraryExample::Pin::getState()
 }
 bool UberLibraryExample::Pin::getMode()
 {
-  return mode;
+  return getPinMode(number) == OUTPUT ? true: false;
 }
 bool UberLibraryExample::Pin::isHigh()
 {

--- a/firmware/uber-library-example.h
+++ b/firmware/uber-library-example.h
@@ -17,7 +17,6 @@ namespace UberLibraryExample
   {
     private:
       int number;
-      int mode;
       bool state;
     public:
       Pin(int _number);


### PR DESCRIPTION
Fixed issue where the "mode" variable never changed when the beginInPinMode(PinMode _pinMode) was called. Removed the variable "mode" and now return the pin mode regardless of how it was written (either with beginInPinMode or manually in a setup file with pinMode).

*Note: I left the type of getMode() as boolean but this will only tell you if the pin mode is output or input, not pull-up/pull-down input.*